### PR TITLE
Use HTTPS for the request to git.io and for URLs

### DIFF
--- a/lib/gitio.js
+++ b/lib/gitio.js
@@ -13,12 +13,12 @@
 var request = require('request');
 
 var payload = {
-	url: process.argv[2],
+	url: process.argv[2].replace(/^http:/,'https:'),
 	code: process.argv[3]
 };
 
 request.post({
-	url: 'http://git.io',
+	url: 'https://git.io',
 	form: payload
 }, function(err, res, body) {
 	if(err) {
@@ -26,11 +26,12 @@ request.post({
 	}
 	var statusCode = res.headers.status.split(' ')[0];
 	if(statusCode == '201') {
-		console.log('\nCongratulations! You can access your URL at ' + res.headers.location + '\n');
+		console.log('\nCongratulations! You can access your URL at '
+			+ res.headers.location.replace('^http:','https:') + '\n');
 	} else if (statusCode == '422') {
 		console.log('\nOne of two things went wrong:\n\n');
 		console.log('  - You may have tried to shorten a link not hosted on Github.com\n');
-		console.log('  - http://git.io/' + payload.code + ' was already taken\n\n');
+		console.log('  - https://git.io/' + payload.code + ' was already taken\n\n');
 	}
 });
 


### PR DESCRIPTION
It changes gitio.js to:
1. use https to connect to the git.io service (for security)
2. convert http to https in source URLs (the http didn't work before)
3. display the https version of the shortened URL (for security)

Re: 1 and 3 - using http you may be vulnerable to MITM attacks
and evesdropping during both link shortening and using.

Re: 2 - Before the change using http links didn't work at all:

```
$ ./gitio.js http://github.com/rsp/ppj/blob/master/WhereEven.scm

One of two things went wrong:
  - You may have tried to shorten a link not hosted on Github.com
  - http://git.io/undefined was already taken
```

After the change:

```
$ ./gitio.js http://github.com/rsp/ppj/blob/master/WhereEven.scm

Congratulations! You can access your URL at https://git.io/vBZLB
```
